### PR TITLE
fix: NV12/21Bufferへの変換処理修正

### DIFF
--- a/core/src/main/java/io/github/crow_misia/libyuv/CapacityCalculator.kt
+++ b/core/src/main/java/io/github/crow_misia/libyuv/CapacityCalculator.kt
@@ -18,6 +18,15 @@ value class RowStride(val value: Int) {
     }
 }
 
+@JvmInline
+value class PixelStride(val value: Int) {
+    override fun toString(): String = value.toString()
+
+    companion object {
+        val ONE = PixelStride(1)
+    }
+}
+
 interface PlaneCapacities
 
 data class Plane1Capacities(

--- a/core/src/main/java/io/github/crow_misia/libyuv/Plane.kt
+++ b/core/src/main/java/io/github/crow_misia/libyuv/Plane.kt
@@ -9,7 +9,9 @@ import kotlin.math.min
 
 abstract class Plane {
     abstract val rowStride: RowStride
+    abstract val pixelStride: PixelStride
     abstract val buffer: ByteBuffer
+    abstract val bufferSize: Int
 
     fun hashDjb2(): Long = hashDjb2(5381)
 

--- a/core/src/main/java/io/github/crow_misia/libyuv/PlaneNative.kt
+++ b/core/src/main/java/io/github/crow_misia/libyuv/PlaneNative.kt
@@ -3,13 +3,19 @@ package io.github.crow_misia.libyuv
 import android.media.Image
 import java.nio.ByteBuffer
 
-data class PlaneNative(
+data class PlaneNative @JvmOverloads constructor(
     private val plane: Image.Plane,
+    override val buffer: ByteBuffer = plane.buffer,
+    override val bufferSize: Int = buffer.capacity(),
 ) : Plane() {
-    override val buffer: ByteBuffer = plane.buffer
     override val rowStride: RowStride = RowStride(plane.rowStride)
+    override val pixelStride: PixelStride = PixelStride(plane.pixelStride)
 }
 
-fun Image.Plane.asPlane(): Plane {
-    return PlaneNative(plane = this)
+fun Image.Plane.asPlane(bufferSize: Int = buffer.capacity()): Plane {
+    return PlaneNative(
+        plane = this,
+        buffer = buffer,
+        bufferSize = bufferSize,
+    )
 }

--- a/core/src/main/java/io/github/crow_misia/libyuv/PlanePrimitive.kt
+++ b/core/src/main/java/io/github/crow_misia/libyuv/PlanePrimitive.kt
@@ -4,5 +4,28 @@ import java.nio.ByteBuffer
 
 data class PlanePrimitive(
     override val rowStride: RowStride,
+    override val pixelStride: PixelStride,
     override val buffer: ByteBuffer,
-) : Plane()
+    override val bufferSize: Int,
+) : Plane() {
+    constructor(
+        rowStride: RowStride,
+        buffer: ByteBuffer,
+    ) : this(
+        rowStride = rowStride,
+        pixelStride = PixelStride.ONE,
+        buffer = buffer,
+        bufferSize = buffer.limit(),
+    )
+
+    constructor(
+        rowStride: RowStride,
+        pixelStride: PixelStride,
+        buffer: ByteBuffer,
+    ) : this(
+        rowStride = rowStride,
+        pixelStride = pixelStride,
+        buffer = buffer,
+        bufferSize = buffer.limit(),
+    )
+}

--- a/core/src/main/java/io/github/crow_misia/libyuv/PlaneProxy.kt
+++ b/core/src/main/java/io/github/crow_misia/libyuv/PlaneProxy.kt
@@ -3,13 +3,19 @@ package io.github.crow_misia.libyuv
 import androidx.camera.core.ImageProxy
 import java.nio.ByteBuffer
 
-data class PlaneProxy(
+data class PlaneProxy @JvmOverloads constructor(
     private val proxy: ImageProxy.PlaneProxy,
+    override val buffer: ByteBuffer = proxy.buffer,
+    override val bufferSize: Int = buffer.capacity(),
 ) : Plane() {
-    override val buffer: ByteBuffer = proxy.buffer
     override val rowStride: RowStride = RowStride(proxy.rowStride)
+    override val pixelStride: PixelStride = PixelStride(proxy.pixelStride)
 }
 
-fun ImageProxy.PlaneProxy.asPlane(): Plane {
-    return PlaneProxy(proxy = this)
+fun ImageProxy.PlaneProxy.asPlane(bufferSize: Int = buffer.capacity()): Plane {
+    return PlaneProxy(
+        proxy = this,
+        buffer = buffer,
+        bufferSize = bufferSize,
+    )
 }

--- a/core/src/main/java/io/github/crow_misia/libyuv/ext/ImageExt.kt
+++ b/core/src/main/java/io/github/crow_misia/libyuv/ext/ImageExt.kt
@@ -1,6 +1,9 @@
 package io.github.crow_misia.libyuv.ext
 
+import android.graphics.ImageFormat
 import android.media.Image
+import android.media.Image.Plane
+import androidx.camera.core.ImageProxy
 import io.github.crow_misia.libyuv.AbgrBuffer
 import io.github.crow_misia.libyuv.Argb1555Buffer
 import io.github.crow_misia.libyuv.Argb4444Buffer
@@ -19,6 +22,7 @@ import io.github.crow_misia.libyuv.J422Buffer
 import io.github.crow_misia.libyuv.J444Buffer
 import io.github.crow_misia.libyuv.Nv12Buffer
 import io.github.crow_misia.libyuv.Nv21Buffer
+import io.github.crow_misia.libyuv.PixelStride
 import io.github.crow_misia.libyuv.RawBuffer
 import io.github.crow_misia.libyuv.Rgb24Buffer
 import io.github.crow_misia.libyuv.Rgb565Buffer
@@ -303,9 +307,16 @@ object ImageExt {
      */
     @JvmStatic
     fun Image.toNv12Buffer(): Nv12Buffer {
+        val planeU = planes[1]
+        val planeV = planes[2]
+        val planeUV = when (planeU.pixelStride) {
+            1 -> planeU.asPlane(planeU.buffer.capacity() + planeV.buffer.capacity())
+            2 -> planeU.asPlane(planeU.buffer.capacity() + 1)
+            else -> error("Supported pixel strides for U and V planes are 1 and 2")
+        }
         return Nv12Buffer.wrap(
             planeY = planes[0].asPlane(),
-            planeUV = planes[1].asPlane(),
+            planeUV = planeUV,
             width = width,
             height = height,
             cropRect = cropRect,
@@ -319,9 +330,16 @@ object ImageExt {
      */
     @JvmStatic
     fun Image.toNv21Buffer(): Nv21Buffer {
+        val planeU = planes[1]
+        val planeV = planes[2]
+        val planeVU = when (planeV.pixelStride) {
+            1 -> planeV.asPlane(planeU.buffer.capacity() + planeV.buffer.capacity())
+            2 -> planeV.asPlane(planeV.buffer.capacity() + 1)
+            else -> error("Supported pixel strides for U and V planes are 1 and 2")
+        }
         return Nv21Buffer.wrap(
             planeY = planes[0].asPlane(),
-            planeVU = planes[1].asPlane(),
+            planeVU = planeVU,
             width = width,
             height = height,
             cropRect = cropRect,

--- a/core/src/main/java/io/github/crow_misia/libyuv/ext/ImageProxyExt.kt
+++ b/core/src/main/java/io/github/crow_misia/libyuv/ext/ImageProxyExt.kt
@@ -1,5 +1,7 @@
 package io.github.crow_misia.libyuv.ext
 
+import android.graphics.ImageFormat
+import android.media.Image.Plane
 import androidx.camera.core.ImageProxy
 import io.github.crow_misia.libyuv.AbgrBuffer
 import io.github.crow_misia.libyuv.Argb1555Buffer
@@ -19,6 +21,8 @@ import io.github.crow_misia.libyuv.J422Buffer
 import io.github.crow_misia.libyuv.J444Buffer
 import io.github.crow_misia.libyuv.Nv12Buffer
 import io.github.crow_misia.libyuv.Nv21Buffer
+import io.github.crow_misia.libyuv.PixelStride
+import io.github.crow_misia.libyuv.PlaneProxy
 import io.github.crow_misia.libyuv.RawBuffer
 import io.github.crow_misia.libyuv.Rgb24Buffer
 import io.github.crow_misia.libyuv.Rgb565Buffer
@@ -304,9 +308,16 @@ object ImageProxyExt {
      */
     @JvmStatic
     fun ImageProxy.toNv12Buffer(): Nv12Buffer {
+        val planeU = planes[1]
+        val planeV = planes[2]
+        val planeUV = when (planeU.pixelStride) {
+            1 -> planeU.asPlane(planeU.buffer.capacity() + planeV.buffer.capacity())
+            2 -> planeU.asPlane(planeU.buffer.capacity() + 1)
+            else -> error("Supported pixel strides for U and V planes are 1 and 2")
+        }
         return Nv12Buffer.wrap(
             planeY = planes[0].asPlane(),
-            planeUV = planes[1].asPlane(),
+            planeUV = planeUV,
             width = width,
             height = height,
             cropRect = cropRect,
@@ -320,9 +331,16 @@ object ImageProxyExt {
      */
     @JvmStatic
     fun ImageProxy.toNv21Buffer(): Nv21Buffer {
+        val planeU = planes[1]
+        val planeV = planes[2]
+        val planeVU = when (planeV.pixelStride) {
+            1 -> planeV.asPlane(planeU.buffer.capacity() + planeV.buffer.capacity())
+            2 -> planeV.asPlane(planeV.buffer.capacity() + 1)
+            else -> error("Supported pixel strides for U and V planes are 1 and 2")
+        }
         return Nv21Buffer.wrap(
             planeY = planes[0].asPlane(),
-            planeVU = planes[1].asPlane(),
+            planeVU = planeVU,
             width = width,
             height = height,
             cropRect = cropRect,


### PR DESCRIPTION
refs #132 

android.media.Image/androidx.camera.core.ImageProxyから、NV12/21Bufferへの変換処理修正

- ImageFormatがYUV_420_888の場合、Image/ImageProxyのplanes[2]にV Planeが入るが、NV21の場合に無視されていた
- 機種によって、planes[1]にU Plane, planes[2]にV Planeが格納され、pixelStrideが2の場合があり、bufferは1plane分のサイズを返す そのため、1バイト分サイズが小さくなる pixelStrideが2の場合、1バイトサイズ加算し、UV/VU Planeとして扱う (planeにバッファサイズとpixelStrideを持つ) ByteBufferのputでは、capacityを超えてコピー出来ないため、JNIのmemcopy関数でコピーを行う