### PR TITLE
build: buildSrcからbuild-logic/propertiesにバージョンやpom定義を移行

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation(libs.maven.publish)
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,12 @@
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    versionCatalogs {
+        register("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/publish.gradle.kts
+++ b/build-logic/src/main/kotlin/publish.gradle.kts
@@ -1,0 +1,27 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
+
+plugins {
+    `maven-publish`
+    id("com.vanniktech.maven.publish")
+    id("signing")
+}
+
+signing {
+    useGpgCmd()
+    sign(publishing.publications)
+}
+
+mavenPublishing {
+    configure(AndroidSingleVariantLibrary(
+        variant = "release",
+        javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationJavadoc"),
+        sourcesJar = SourcesJar.Sources(),
+    ))
+
+    publishToMavenCentral()
+
+    coordinates()
+}
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.dokka) apply false
     alias(libs.plugins.dokka.javadoc) apply false
-    alias(libs.plugins.maven.publish) apply false
 }
 
 buildscript {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,0 @@
-plugins {
-    `kotlin-dsl`
-}
-
-repositories {
-    mavenCentral()
-}

--- a/buildSrc/src/main/java/Build.kt
+++ b/buildSrc/src/main/java/Build.kt
@@ -1,9 +1,0 @@
-import org.gradle.api.JavaVersion
-
-object Build {
-    const val COMPILE_SDK = 36
-    const val MIN_SDK = 23
-    const val TARGET_SDK = 35
-    const val NDK_VERSION = "28.1.13356709"
-    val jvmTarget = JavaVersion.VERSION_11
-}

--- a/buildSrc/src/main/java/Maven.kt
+++ b/buildSrc/src/main/java/Maven.kt
@@ -1,7 +1,0 @@
-object Maven {
-    const val GROUP_ID = "io.github.crow-misia.libyuv"
-    const val ARTIFACT_ID = "libyuv-android"
-    const val DESCRIPTION = "LibYuv for Android"
-    const val VERSION = "0.43.2"
-    const val GITHUB_REPOSITORY = "crow-misia/libyuv-android"
-}

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -11,6 +11,6 @@ tag = true
 push = false
 
 [bumpver.file_patterns]
-"core/build.gradle.kts" = [
-    "    const val VERSION = \"{pep440_version}\"",
+"gradle.properties" = [
+    "VERSION_NAME={pep440_version}",
 ]

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.SourcesJar
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
@@ -9,19 +6,15 @@ plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.dokka)
     alias(libs.plugins.dokka.javadoc)
-    alias(libs.plugins.maven.publish)
-    id("signing")
+    id("publish")
 }
-
-group = Maven.GROUP_ID
-version = Maven.VERSION
 
 android {
     namespace = "io.github.crow_misia.libyuv"
-    compileSdk = Build.COMPILE_SDK
+    compileSdk = libs.versions.android.compile.sdk.get().toInt()
 
     defaultConfig {
-        minSdk = Build.MIN_SDK
+        minSdk = libs.versions.android.min.sdk.get().toInt()
         consumerProguardFiles("consumer-proguard-rules.pro")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -46,7 +39,7 @@ android {
             path(File("${projectDir}/Android.mk"))
         }
     }
-    ndkVersion = Build.NDK_VERSION
+    ndkVersion = libs.versions.android.ndk.get()
 
     sourceSets {
         named("androidTest") {
@@ -71,8 +64,9 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = Build.jvmTarget
-        targetCompatibility = Build.jvmTarget
+        val javaVersion = JavaVersion.toVersion(libs.versions.java.get())
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
     }
 
     packaging {
@@ -85,7 +79,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.fromTarget(Build.jvmTarget.toString())
+        jvmTarget = JvmTarget.fromTarget(libs.versions.java.get())
         languageVersion = KotlinVersion.KOTLIN_2_2
         apiVersion = KotlinVersion.KOTLIN_2_2
     }
@@ -102,48 +96,6 @@ dependencies {
     androidTestImplementation(libs.androidx.test.ext.truth)
     androidTestImplementation(libs.androidx.test.espresso.core)
     androidTestImplementation(libs.truth)
-}
-
-signing {
-    useGpgCmd()
-    sign(publishing.publications)
-}
-
-mavenPublishing {
-    configure(AndroidSingleVariantLibrary(
-        variant = "release",
-        javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationJavadoc"),
-        sourcesJar = SourcesJar.Sources(),
-    ))
-
-    publishToMavenCentral()
-
-    coordinates(Maven.GROUP_ID, Maven.ARTIFACT_ID, Maven.VERSION)
-
-    pom {
-        name = Maven.ARTIFACT_ID
-        description = Maven.DESCRIPTION
-        url = "https://github.com/${Maven.GITHUB_REPOSITORY}/"
-        licenses {
-            license {
-                name = "Apache-2.0"
-                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                distribution = "repo"
-            }
-        }
-        developers {
-            developer {
-                id = "crow-misia"
-                name = "Zenichi Amano"
-                email = "crow.misia@gmail.com"
-            }
-        }
-        scm {
-            url = "https://github.com/${Maven.GITHUB_REPOSITORY}/"
-            connection = "scm:git:git://github.com/${Maven.GITHUB_REPOSITORY}.git"
-            developerConnection = "scm:git:ssh://git@github.com/${Maven.GITHUB_REPOSITORY}.git"
-        }
-    }
 }
 
 detekt {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,24 @@ org.gradle.jvmargs=-Xmx1536m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+
+# POM
+GROUP=io.github.crow-misia.libyuv
+POM_ARTIFACT_ID=libyuv-android
+VERSION_NAME=0.43.2
+
+POM_NAME=libyuv-android
+POM_DESCRIPTION=LibYuv for Android
+POM_URL=https://github.com/crow-misia/libyuv-android/
+
+POM_LICENSE_NAME=Apache-2.0
+POM_LICENSE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENSE_DIST=repo
+
+POM_SCM_URL=https://github.com/crow-misia/libyuv-android/
+POM_SCM_CONNECTION=scm:git:git://github.com/crow-misia/libyuv-android.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/crow-misia/libyuv-android.git
+
+POM_DEVELOPER_ID=crow-misia
+POM_DEVELOPER_NAME=Zenichi Amano
+POM_DEVELOPER_EMAIL=crow.misia@gmail.com

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,21 @@
 
 [versions]
 
+java = "11"
+
+android-min-sdk = "23"
+
+android-compile-sdk = "36"
+
+android-target-sdk = "35"
+
+android-ndk = "28.1.13356709"
+
 android-gradle-plugin = "9.2.1"
 
 android-tools-desugar_jdk_libs = "2.1.5"
+
+androidx-annotation = "1.10.0"
 
 androidx-camera = "1.6.1"
 
@@ -34,7 +46,7 @@ truth = "1.4.5"
 
 [libraries]
 
-androidx-annotation = { group = "androidx.annotation", name = "annotation", version = "1.10.0" }
+androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidx-annotation" }
 
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "androidx-activity" }
 
@@ -58,6 +70,8 @@ kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-p
 
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 
+maven-publish = { group = "com.vanniktech", name = "gradle-maven-publish-plugin", version.ref = "maven-publish" }
+
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 
 [plugins]
@@ -71,5 +85,3 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 
 dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
-
-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -5,12 +5,13 @@ plugins {
 }
 
 android {
-    compileSdk = Build.COMPILE_SDK
+    compileSdk = libs.versions.android.compile.sdk.get().toInt()
     defaultConfig {
         namespace = "app"
         applicationId = "com.github.crow_misia.libyuv"
-        minSdk = Build.MIN_SDK
-        targetSdk = Build.TARGET_SDK
+        minSdk = libs.versions.android.min.sdk.get().toInt()
+        //noinspection OldTargetApi
+        targetSdk = libs.versions.android.target.sdk.get().toInt()
         versionCode = 1
         versionName = "1.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -36,15 +37,16 @@ android {
     }
 
     compileOptions {
+        val javaVersion = JavaVersion.toVersion(libs.versions.java.get())
         isCoreLibraryDesugaringEnabled = true
-        sourceCompatibility = Build.jvmTarget
-        targetCompatibility = Build.jvmTarget
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
     }
 }
 
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.fromTarget(Build.jvmTarget.toString())
+        jvmTarget = JvmTarget.fromTarget(libs.versions.java.get())
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,16 @@
 pluginManagement {
     repositories {
-        gradlePluginPortal()
-        google()
+        google {
+            content {
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+                includeGroupAndSubgroups("androidx")
+            }
+        }
         mavenCentral()
+        gradlePluginPortal()
     }
+    includeBuild("build-logic")
 }
 
 plugins {
@@ -13,7 +20,13 @@ plugins {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        google()
+        google {
+            content {
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+                includeGroupAndSubgroups("androidx")
+            }
+        }
         mavenCentral()
     }
 }
@@ -23,5 +36,5 @@ refreshVersions {
 }
 
 rootProject.name = "libyuv-android"
-include("core")
-include("sample")
+include(":core")
+include(":sample")


### PR DESCRIPTION
バージョン変更のみでビルドキャッシュが無効にならないようにし、ビルド時間短縮を図る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Maven Central への公開に対応し、配布・署名・メタデータ生成の仕組みを整備しました。
  * バージョン更新時に関連ファイルも自動反映されるようになりました。

* **変更**
  * Android/Java/Kotlin のビルド設定を最新のバージョン定義へ整理しました。
  * 依存関係の取得元を明示し、必要なリポジトリのみを参照するようにしました。
  * サンプルアプリとコアモジュールのビルド設定を共通化し、管理しやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->